### PR TITLE
Make fixups

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ Vagrant 1.8.1
 5.0.20r106931
 ```
 
+> Note: Vagrant is used in the build process to create an RPM for RHEL systems. Supported OSes for building cosi are CentOS, Ubuntu and OSX (what Vagrant supports).
+
 ```sh
 # get the source, change the URL if you're using a forked copy
 git clone https://github.com/circonus-labs/circonus-one-step-install

--- a/README.md
+++ b/README.md
@@ -60,15 +60,12 @@ Vagrant 1.8.1
 # get the source, change the URL if you're using a forked copy
 git clone https://github.com/circonus-labs/circonus-one-step-install
 
-# install global NPM packages
-npm install -g eslint pac npm-check-updates
+# install global NPM packages (if you will be using 'make check' or want linting in an editor supporting eslint)
+npm install -g eslint npm-check-updates
 
 # install local development and production NPM packages
 cd circonus-one-step-install/src
-npm install
-cd util
-npm install
-cd ..
+make init
 
 # build the cosi-site package for deployment
 make package

--- a/src/Makefile
+++ b/src/Makefile
@@ -48,6 +48,10 @@ install:
 	@echo "Use 'install.sh' for installation of the COSI-Site package *on the target system*"
 	@exit 2
 
+init:
+	test -d node_modules || npm install
+	make -C util init
+	
 
 package: utils $(SITE_TGZ)
 	@echo "Copy cosi-site package to provisioning directory"

--- a/src/util/Makefile
+++ b/src/util/Makefile
@@ -51,6 +51,8 @@ check:
 	eslint $(BIN_SRC) $(LIB_SRC)
 	@ncu --prod
 
+init:
+	test -d node_modules || npm install
 
 .PHONY: clean
 clean:

--- a/src/util/Makefile
+++ b/src/util/Makefile
@@ -29,7 +29,7 @@ $(UTILS): $(BIN_SRC) $(LIB_SRC) package.json Makefile $(STATSD)
 		mv "$$f" "$${f%.js}"; \
 	done
 	$(BABEL) lib -d build/lib
-	pac --production
+	node_modules/.bin/pac --production
 	cp -r .modules build/.
 	cp -r service build/.
 	cp -r rulesets build/.

--- a/src/util/package.json
+++ b/src/util/package.json
@@ -17,6 +17,7 @@
   "devDependencies": {
     "babel-cli": "6.10.1",
     "babel-preset-es2015": "6.9.0",
+    "pac": "1.0.0",
     "tape": "4.6.0"
   },
   "scripts": {


### PR DESCRIPTION
- add note to readme re: vagrant being required for build
- add init target to make files for installing node modules in one command after clone
- move pac to a local dev dependency in util (site does not use it any longer, ansible installs npm modules)
