### PR TITLE
update NAD packages, fix broker selection

### DIFF
--- a/src/etc/circonus-packages.json
+++ b/src/etc/circonus-packages.json
@@ -5,7 +5,7 @@
                 "arch": "x86_64",
                 "package_info": {
                     "package_url": null,
-                    "package_file": "nad-omnibus-20161202T150935Z-1.ubuntu.16.04_amd64.deb",
+                    "package_file": "nad-omnibus-20161216T233411Z-1.ubuntu.16.04_amd64.deb",
                     "publisher_url": null,
                     "publisher_name": null,
                     "package_name": null
@@ -17,7 +17,7 @@
                 "arch": "i386",
                 "package_info": {
                     "package_url": null,
-                    "package_file": "nad-omnibus-20161202T150935Z-1.ubuntu.14.04_i386.deb",
+                    "package_file": "nad-omnibus-20161216T233411Z-1.ubuntu.14.04_i386.deb",
                     "publisher_url": null,
                     "publisher_name": null,
                     "package_name": null
@@ -27,7 +27,7 @@
                 "arch": "x86_64",
                 "package_info": {
                     "package_url": null,
-                    "package_file": "nad-omnibus-20161202T150935Z-1.ubuntu.14.04_amd64.deb",
+                    "package_file": "nad-omnibus-20161216T233411Z-1.ubuntu.14.04_amd64.deb",
                     "publisher_url": null,
                     "publisher_name": null,
                     "package_name": null
@@ -39,7 +39,7 @@
                 "arch": "i386",
                 "package_info": {
                     "package_url": null,
-                    "package_file": "nad-omnibus-20161202T150935Z-1.ubuntu.12.04_i386.deb",
+                    "package_file": "nad-omnibus-20161216T233411Z-1.ubuntu.12.04_i386.deb",
                     "publisher_url": null,
                     "publisher_name": null,
                     "package_name": null
@@ -49,7 +49,7 @@
                 "arch": "x86_64",
                 "package_info": {
                     "package_url": null,
-                    "package_file": "nad-omnibus-20161202T150935Z-1.ubuntu.12.04_amd64.deb",
+                    "package_file": "nad-omnibus-20161216T233411Z-1.ubuntu.12.04_amd64.deb",
                     "publisher_url": null,
                     "publisher_name": null,
                     "package_name": null
@@ -63,7 +63,7 @@
                 "arch": "x86_64",
                 "package_info": {
                     "package_url": null,
-                    "package_file": "nad-omnibus-20161202T150935Z-1.el5.x86_64.rpm",
+                    "package_file": "nad-omnibus-20161216T233411Z-1.el5.x86_64.rpm",
                     "publisher_url": null,
                     "publisher_name": null,
                     "package_name": null
@@ -73,7 +73,7 @@
                 "arch": "i386",
                 "package_info": {
                     "package_url": null,
-                    "package_file": "nad-omnibus-20161202T150935Z-1.el5.i386.rpm",
+                    "package_file": "nad-omnibus-20161216T233411Z-1.el5.i386.rpm",
                     "publisher_url": null,
                     "publisher_name": null,
                     "package_name": null
@@ -85,7 +85,7 @@
                 "arch": "x86_64",
                 "package_info": {
                     "package_url": null,
-                    "package_file": "nad-omnibus-20161202T150935Z-1.el6.x86_64.rpm",
+                    "package_file": "nad-omnibus-20161216T233411Z-1.el6.x86_64.rpm",
                     "publisher_url": null,
                     "publisher_name": null,
                     "package_name": null
@@ -95,7 +95,7 @@
                 "arch": "i686",
                 "package_info": {
                     "package_url": null,
-                    "package_file": "nad-omnibus-20161202T150935Z-1.el6.i686.rpm",
+                    "package_file": "nad-omnibus-20161216T233411Z-1.el6.i686.rpm",
                     "publisher_url": null,
                     "publisher_name": null,
                     "package_name": null
@@ -107,7 +107,7 @@
                 "arch": "x86_64",
                 "package_info": {
                     "package_url": null,
-                    "package_file": "nad-omnibus-20161202T150935Z-1.el7.x86_64.rpm",
+                    "package_file": "nad-omnibus-20161216T233411Z-1.el7.x86_64.rpm",
                     "publisher_url": null,
                     "publisher_name": null,
                     "package_name": null
@@ -121,7 +121,7 @@
                 "arch": "x86_64",
                 "package_info": {
                     "package_url": null,
-                    "package_file": "nad-omnibus-20161202T150935Z-1.el7.x86_64.rpm",
+                    "package_file": "nad-omnibus-20161216T233411Z-1.el7.x86_64.rpm",
                     "publisher_url": null,
                     "publisher_name": null,
                     "package_name": null
@@ -133,7 +133,7 @@
                 "arch": "x86_64",
                 "package_info": {
                     "package_url": null,
-                    "package_file": "nad-omnibus-20161202T150935Z-1.el6.x86_64.rpm",
+                    "package_file": "nad-omnibus-20161216T233411Z-1.el6.x86_64.rpm",
                     "publisher_url": null,
                     "publisher_name": null,
                     "package_name": null
@@ -147,7 +147,7 @@
                 "arch": "x86_64",
                 "package_info": {
                     "package_url": null,
-                    "package_file": "nad-omnibus-20161202T150935Z-1.el7.x86_64.rpm",
+                    "package_file": "nad-omnibus-20161216T233411Z-1.el7.x86_64.rpm",
                     "publisher_url": null,
                     "publisher_name": null,
                     "package_name": null
@@ -175,7 +175,7 @@
                 "arch": "x86_64",
                 "package_info": {
                     "package_url": null,
-                    "package_file": "nad-omnibus-20161202T150935Z-1.el6.x86_64.rpm",
+                    "package_file": "nad-omnibus-20161216T233411Z-1.el6.x86_64.rpm",
                     "publisher_url": null,
                     "publisher_name": null,
                     "package_name": null

--- a/src/util/lib/cosi/broker/index.js
+++ b/src/util/lib/cosi/broker/index.js
@@ -366,6 +366,7 @@ class Broker {
         }
 
         const enterpriseBrokers = [];
+        let numValidBrokers = 0;
 
         for (let i = 0; i < brokerList.length; i++) {
             const broker = brokerList[i];
@@ -376,6 +377,9 @@ class Broker {
             if (!this._isValidBroker(broker, checkType)) {
                 continue;
             }
+
+            numValidBrokers += 1;
+
             for (let j = 0; j < broker._details.length; j++) {
                 const detail = broker._details[j];
 
@@ -391,6 +395,10 @@ class Broker {
         }
 
         if (enterpriseBrokers.length === 0) {
+            if (numValidBrokers > 0) {
+                console.error(chalk.red('ERROR:'), numValidBrokers, 'enterprise brokers found, none could be reached.');
+                process.exit(1);
+            }
             return null;
         }
 
@@ -433,11 +441,8 @@ class Broker {
     _brokerConnectionTest(detail, maxResponseTime) {
         const maxTime = maxResponseTime || 500;
         const port = detail.external_port || 43191;
-        let host = detail.ipaddress;
-
-        if (detail.cn === detail.external_host) {
-            host = detail.external_host;
-        }
+        // preference external_host, if not defined use broker's IP
+        const host = detail.external_host || detail.ipaddress;
 
         const status = ct.test(host, port, maxTime);
 


### PR DESCRIPTION
* error if enterprise brokers present but not valid
* use `external_host` over `ipaddress` in broker test
* update NAD packages to 20161216T233411Z release
