### PR TITLE
v2.3.2

### DIFF
--- a/provision/cosi-site.yml
+++ b/provision/cosi-site.yml
@@ -2,7 +2,7 @@
 - hosts: all
   vars:
     # update when src/package.json version bumped and ready for release
-    cosi_site_version: "2.3.1"
+    cosi_site_version: "2.3.2"
     # if using omnios, ensure node_version is built and appropriate node and
     # modules tgz's are placed in roles/{site,node}/files directories
     # respectively.

--- a/src/CHAGNELOG.md
+++ b/src/CHAGNELOG.md
@@ -1,3 +1,9 @@
+### 2.3.2 2017-08-24
+
+* upd: create use dashboard regardless of graph availability
+* upd: do not disable diskstats plugin when required proc files not present
+* fix: do not create graphs with 0 datapoints
+
 ### 2.3.1 2017-08-24
 
 * fix: restore --target functionality for system check

--- a/src/content/files/cosi-install.sh
+++ b/src/content/files/cosi-install.sh
@@ -528,22 +528,6 @@ __install_agent() {
     [[ -d "${base_dir}/nad" ]] && agent_dir="${base_dir}/nad"
     [[ -d "${base_dir}/etc" ]] || mkdir -p "${base_dir}/etc"
 
-    # plugin fixups
-    local plugin_dir="${agent_dir}/etc/node-agent.d"
-    log "Checking $plugin_dir"
-    if [[ -d $plugin_dir ]]; then
-        local plugin="${plugin_dir}/diskstats.sh"
-        log "Checking $plugin"
-        if [[ -h $plugin ]]; then
-            # diskstats.sh installed by default on linux
-            # but required /proc files not always present.
-            [[ -f /proc/mdstat && -f /proc/diskstats ]] || {
-                log "requirements missing, removing $plugin"
-                rm $plugin
-            }
-        fi
-    fi
-
     # callout hook placeholder (POST)
     if [[ -n "${agent_post_hook:-}" && -x "${agent_post_hook}" ]]; then
         log "Agent POST hook found, running..."

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosi-site",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "private": true,
   "license": "SEE LICENSE IN LICENSE",
   "description": "Circonus One Step Install registration API",

--- a/src/util/lib/cosi/registration/dashboards/index.js
+++ b/src/util/lib/cosi/registration/dashboards/index.js
@@ -450,10 +450,11 @@ class Dashboards extends Registration {
             }
 
             if (missing_widgets > 0 && (/template-dashboard-system/).test(template.file)) {
-                console.log(chalk.yellow('\tWARN'), 'Not all system dashboard widgets found, skipping creation.');
-                resolve();
-
-                return;
+                console.log(chalk.yellow('\tWARN'), 'Not all system dashboard widgets found, dashboard will be created without missing visuals.');
+                // no longer prevent creating the dashboard - create incomplete dashboard instead...
+                // resolve();
+                //
+                // return;
             }
 
             try {

--- a/src/util/lib/cosi/registration/graphs/index.js
+++ b/src/util/lib/cosi/registration/graphs/index.js
@@ -357,6 +357,12 @@ class Graphs extends Registration {
         }
         graph.datapoints = datapoints_filled;
 
+        if (graph.datapoints.length === 0) {
+            console.log(chalk.yellow('\tWARN'), 'Graph has no datapoints, skipping.');
+
+            return;
+        }
+
         this._setTags(graph, graphId);
         this._setCustomGraphOptions(graph, graphId);
 

--- a/src/util/package.json
+++ b/src/util/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosi-cli",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "description": "Circonus One Step Install utility",
   "private": true,
   "author": "matt maier (https://github.com/maier)",


### PR DESCRIPTION
* upd: create use dashboard regardless of graph availability
* upd: do not disable diskstats plugin when required proc files not present
* fix: do not create graphs with 0 datapoints
