### PR TITLE
v2.4.2

### DIFF
--- a/demo/Vagrantfile
+++ b/demo/Vagrantfile
@@ -17,6 +17,7 @@ Vagrant.configure(2) do |config|
         # leverage main 'cosi-site' ansible playbook
         site.vm.provision 'ansible' do |ansible|
             # ansible.verbose = 'vvvv'
+            ansible.compatibility_mode = '2.0'
             ansible.playbook = '../provision/cosi-site.yml'
         end
     end

--- a/provision/cosi-site.yml
+++ b/provision/cosi-site.yml
@@ -3,13 +3,11 @@
   vars:
     # update when src/package.json version bumped and ready for release
     cosi_site_version: "2.4.1"
-    # if using omnios, ensure node_version is built and appropriate node and
-    # modules tgz's are placed in roles/{site,node}/files directories
-    # respectively.
-    node_version: "4.4.5"
     # note, **just** the file name, not a "path" the specified file is expected
     # to be in ./content/files relative to cosi-site.js
     installer_rpm_file: "cosi-{{ cosi_site_version }}-1.noarch.rpm"
+    # what port should the cosi-site daemon listen on
+    site_port: 80
   roles:
     - os
     - node

--- a/provision/roles/node/tasks/Linux.yml
+++ b/provision/roles/node/tasks/Linux.yml
@@ -11,6 +11,7 @@
   args:
     chdir: "{{ node_directory }}"
   changed_when: false
+  check_mode: no
 
 - debug: msg="Found Node {{ node_ver_result.stdout }} want v{{ node_version }}"
   when: node_ver_result.rc == 0

--- a/provision/roles/node/tasks/main.yml
+++ b/provision/roles/node/tasks/main.yml
@@ -19,7 +19,7 @@
         skip: true
 
 - name: Install
-  include: "{{ item }}"
+  include_tasks: "{{ item }}"
   with_first_found:
     - "{{ ansible_distribution }}-{{ ansible_distribution_version }}.yml"
     - "{{ ansible_distribution }}-{{ ansible_distribution_major_version }}.yml"

--- a/provision/roles/node/vars/Linux.yml
+++ b/provision/roles/node/vars/Linux.yml
@@ -1,4 +1,5 @@
 ---
+
 node_arch: "x{{ '86' if ansible_userspace_bits == '32' else '64' if ansible_userspace_bits == '64' else 'UNK'}}"
 
 node_tar_file: node-v{{ node_version }}-{{ ansible_system|lower }}-{{ node_arch }}.tar.xz

--- a/provision/roles/node/vars/OmniOS.yml
+++ b/provision/roles/node/vars/OmniOS.yml
@@ -2,3 +2,8 @@
 
 # override default group
 node_group: bin
+
+# if using omnios, ensure node_version is built and appropriate node and
+# modules tgz's are placed in roles/{site,node}/files directories
+# respectively.
+node_version: "4.4.5"

--- a/provision/roles/node/vars/common.yml
+++ b/provision/roles/node/vars/common.yml
@@ -1,5 +1,8 @@
 ---
 
+#node_version: "8.9.4"
+node_version: "4.4.5"
+
 #
 # the base directory where binaries are expected to be in ./bin. e.g.
 #   {{ node_directory }}/bin/node

--- a/provision/roles/os/tasks/main.yml
+++ b/provision/roles/os/tasks/main.yml
@@ -6,7 +6,7 @@
   include_vars: "../vars/common.yml"
 
 - name: Common tasks
-  include: "common.yml"
+  import_tasks: "common.yml"
 
 - name: OS Specific variables
   include_vars: "{{ item }}"
@@ -20,7 +20,7 @@
         skip: true
 
 - name: OS Specific tasks
-  include: "{{ item }}"
+  include_tasks: "{{ item }}"
   with_first_found:
       - files:
           - "{{ ansible_distribution }}-{{ ansible_distribution_version }}.yml"

--- a/provision/roles/site/tasks/main.yml
+++ b/provision/roles/site/tasks/main.yml
@@ -18,10 +18,10 @@
         skip: true
 
 - name: Common tasks
-  include: "common.yml"
+  import_tasks: "common.yml"
 
 - name: OS Specific tasks
-  include: "{{ item }}"
+  include_tasks: "{{ item }}"
   with_first_found:
       - files:
           - "{{ ansible_distribution }}-{{ ansible_distribution_version }}.yml"

--- a/provision/roles/site/templates/cosi-site.json.j2
+++ b/provision/roles/site/templates/cosi-site.json.j2
@@ -1,6 +1,6 @@
 {
     "hostname": "0.0.0.0",
-    "port": 80,
+    "port": {{ site_port }},
     "package_url": "http://updates.circonus.net/node-agent/packages/",
     "package_list_file": "./etc/packages.json",
     "config_dir": "./etc/configs",

--- a/src/CHAGNELOG.md
+++ b/src/CHAGNELOG.md
@@ -1,3 +1,10 @@
+### 2.4.2 2018-01-19
+
+* update deployment playbook to allow port to be set
+* update deployment playbooks to use explicit 'import_tasks' (static) and 'include_tasks' (dynamic) over deprecated bare 'include'
+* NAD v2.6.0
+* add check for empty hostname in installer
+
 ### 2.4.1 2017-10-23
 
 * NAD v2.5.0

--- a/src/content/files/cosi-install.sh
+++ b/src/content/files/cosi-install.sh
@@ -899,6 +899,12 @@ cosi_initialize() {
         fi
     fi
 
+    hn=$(hostname)
+    if [[ -z "${hn:-}" && -z "${cosi_host_target:-}" ]]; then
+        echo "cosi requires system hostname to be set or overridden with --target"
+        exit 1
+    fi
+
     #
     # optionally, save the cosi-install config
     # (can be used on other systems and/or during testing)

--- a/src/etc/circonus-packages.json
+++ b/src/etc/circonus-packages.json
@@ -5,7 +5,7 @@
                 "arch": "x86_64",
                 "package_info": {
                     "package_url": null,
-                    "package_file": "nad-omnibus-2.5.0-1.ubuntu.16.04_amd64.deb",
+                    "package_file": "nad-omnibus-2.6.0-1.ubuntu.16.04_amd64.deb",
                     "publisher_url": null,
                     "publisher_name": null,
                     "package_name": null
@@ -17,7 +17,7 @@
                 "arch": "i386",
                 "package_info": {
                     "package_url": null,
-                    "package_file": "nad-omnibus-2.5.0-1.ubuntu.14.04_i386.deb",
+                    "package_file": "nad-omnibus-2.6.0-1.ubuntu.14.04_i386.deb",
                     "publisher_url": null,
                     "publisher_name": null,
                     "package_name": null
@@ -27,7 +27,7 @@
                 "arch": "x86_64",
                 "package_info": {
                     "package_url": null,
-                    "package_file": "nad-omnibus-2.5.0-1.ubuntu.14.04_amd64.deb",
+                    "package_file": "nad-omnibus-2.6.0-1.ubuntu.14.04_amd64.deb",
                     "publisher_url": null,
                     "publisher_name": null,
                     "package_name": null
@@ -85,7 +85,7 @@
                 "arch": "x86_64",
                 "package_info": {
                     "package_url": null,
-                    "package_file": "nad-omnibus-2.5.0-1.el6.x86_64.rpm",
+                    "package_file": "nad-omnibus-2.6.0-1.el6.x86_64.rpm",
                     "publisher_url": null,
                     "publisher_name": null,
                     "package_name": null
@@ -95,7 +95,7 @@
                 "arch": "i686",
                 "package_info": {
                     "package_url": null,
-                    "package_file": "nad-omnibus-2.5.0-1.el6.i686.rpm",
+                    "package_file": "nad-omnibus-2.6.0-1.el6.i686.rpm",
                     "publisher_url": null,
                     "publisher_name": null,
                     "package_name": null
@@ -107,7 +107,7 @@
                 "arch": "x86_64",
                 "package_info": {
                     "package_url": null,
-                    "package_file": "nad-omnibus-2.5.0-1.el7.x86_64.rpm",
+                    "package_file": "nad-omnibus-2.6.0-1.el7.x86_64.rpm",
                     "publisher_url": null,
                     "publisher_name": null,
                     "package_name": null
@@ -121,7 +121,7 @@
                 "arch": "x86_64",
                 "package_info": {
                     "package_url": null,
-                    "package_file": "nad-omnibus-2.5.0-1.el7.x86_64.rpm",
+                    "package_file": "nad-omnibus-2.6.0-1.el7.x86_64.rpm",
                     "publisher_url": null,
                     "publisher_name": null,
                     "package_name": null
@@ -133,7 +133,7 @@
                 "arch": "x86_64",
                 "package_info": {
                     "package_url": null,
-                    "package_file": "nad-omnibus-2.5.0-1.el6.x86_64.rpm",
+                    "package_file": "nad-omnibus-2.6.0-1.el6.x86_64.rpm",
                     "publisher_url": null,
                     "publisher_name": null,
                     "package_name": null
@@ -147,7 +147,7 @@
                 "arch": "x86_64",
                 "package_info": {
                     "package_url": null,
-                    "package_file": "nad-omnibus-2.5.0-1.el7.x86_64.rpm",
+                    "package_file": "nad-omnibus-2.6.0-1.el7.x86_64.rpm",
                     "publisher_url": null,
                     "publisher_name": null,
                     "package_name": null
@@ -175,7 +175,7 @@
                 "arch": "x86_64",
                 "package_info": {
                     "package_url": null,
-                    "package_file": "nad-omnibus-2.5.0-1.el6.x86_64.rpm",
+                    "package_file": "nad-omnibus-2.6.0-1.el6.x86_64.rpm",
                     "publisher_url": null,
                     "publisher_name": null,
                     "package_name": null
@@ -187,7 +187,7 @@
                 "arch": "x86_64",
                 "package_info": {
                     "package_url": null,
-                    "package_file": "nad-omnibus-2.5.0-1.el6.x86_64.rpm",
+                    "package_file": "nad-omnibus-2.6.0-1.el6.x86_64.rpm",
                     "publisher_url": null,
                     "publisher_name": null,
                     "package_name": null
@@ -201,7 +201,7 @@
                 "arch": "x86_64",
                 "package_info": {
                     "package_url": null,
-                    "package_file": "nad-omnibus-2.5.0-1.ubuntu.12.04_amd64.deb",
+                    "package_file": "nad-omnibus-2.6.0-1.ubuntu.12.04_amd64.deb",
                     "publisher_url": null,
                     "publisher_name": null,
                     "package_name": null
@@ -213,7 +213,7 @@
                 "arch": "x86_64",
                 "package_info": {
                     "package_url": null,
-                    "package_file": "nad-omnibus-2.5.0-1.ubuntu.16.04_amd64.deb",
+                    "package_file": "nad-omnibus-2.6.0-1.ubuntu.16.04_amd64.deb",
                     "publisher_url": null,
                     "publisher_name": null,
                     "package_name": null
@@ -225,7 +225,7 @@
                 "arch": "x86_64",
                 "package_info": {
                     "package_url": null,
-                    "package_file": "nad-omnibus-2.5.0-1.ubuntu.16.04_amd64.deb",
+                    "package_file": "nad-omnibus-2.6.0-1.ubuntu.16.04_amd64.deb",
                     "publisher_url": null,
                     "publisher_name": null,
                     "package_name": null
@@ -239,7 +239,7 @@
                 "arch": "amd64",
                 "package_info": {
                     "package_url": null,
-                    "package_file": "nad-omnibus-2.5.0-freebsd.11.0-amd64.tar.gz",
+                    "package_file": "nad-omnibus-2.6.0-freebsd.11.0-amd64.tar.gz",
                     "publisher_url": null,
                     "publisher_name": null,
                     "package_name": null


### PR DESCRIPTION
* update deployment playbook to allow port to be set
* update deployment playbooks to use explicit 'import_tasks' (static) and 'include_tasks' (dynamic) over deprecated bare 'include'
* NAD v2.6.0
* add check for empty hostname in installer
