### PR TITLE
Fix names in metric vm datapoints

### DIFF
--- a/src/content/templates/graph-vm.json
+++ b/src/content/templates/graph-vm.json
@@ -68,7 +68,7 @@
                     "color" : "#000000",
                     "data_formula" : null,
                     "legend_formula" : null,
-                    "name" : "vm`meminfo`Buffers",
+                    "name" : "vm`meminfo`Cached",
                     "alpha" : "0.3",
                     "stack" : null
                 },
@@ -81,7 +81,7 @@
                     "color" : "#000000",
                     "data_formula" : null,
                     "legend_formula" : null,
-                    "name" : "vm`meminfo`Buffers",
+                    "name" : "vm`meminfo`MemFree",
                     "alpha" : "0.3",
                     "stack" : null
                 },
@@ -94,7 +94,7 @@
                     "color" : "#000000",
                     "data_formula" : null,
                     "legend_formula" : null,
-                    "name" : "vm`meminfo`Buffers",
+                    "name" : "vm`meminfo`MemTotal",
                     "alpha" : "0.3",
                     "stack" : null
                 }


### PR DESCRIPTION
This PR corrects metric names for Cached, MemTotal, and MemFree datapoints. No functional change, but makes the graph easier to understand.